### PR TITLE
Umbau von pjax auf rex:ready

### DIFF
--- a/assets/cke5.js
+++ b/assets/cke5.js
@@ -7,6 +7,12 @@
 let ckeditors = {},
     ckareas = '.cke5-editor';
 
+$(document).on('rex:ready', function(e, container) {
+    container.find(ckareas).each(function() {
+        cke5_init($(this));
+    });
+})
+
 $(document).on('ready', function () {
     if (typeof mblock_module === 'object') {
         mblock_module.registerCallback('reindex_end', function () {
@@ -17,12 +23,6 @@ $(document).on('ready', function () {
                 }
             }
         });
-    }
-});
-
-$(document).on('ready pjax:success', function () {
-    if ($(ckareas).length) {
-        cke5_init_all($(ckareas));
     }
 });
 


### PR DESCRIPTION
Eigentlich müsste man den ganzen ready kram für mblock noch entfernen. mblock müsste den neuen container jeweils mit rex:ready triggern und dann wäre alles korrekt. Ich schreibe das noch als issue in mblock