### PR TITLE
Bugfix Cke5DatabaseHandler::addProfile

### DIFF
--- a/lib/Cke5/Handler/Cke5DatabaseHandler.php
+++ b/lib/Cke5/Handler/Cke5DatabaseHandler.php
@@ -55,7 +55,6 @@ class Cke5DatabaseHandler
             }
 
             // verify json syntax
-            $description = json_decode($description, true);
             $subOptions = json_decode($subOptions, true);
 
             $now = new \DateTime();

--- a/lib/Cke5/Handler/Cke5DatabaseHandler.php
+++ b/lib/Cke5/Handler/Cke5DatabaseHandler.php
@@ -26,7 +26,17 @@ class Cke5DatabaseHandler
      */
     public static function profileExist($name = null)
     {
-        return (self::loadProfile($name) !== false) ? true : false;
+        try {
+            $sql = rex_sql::factory();
+            $sql->setTable(rex::getTable(Cke5DatabaseHandler::CKE5_PROFILES))
+                ->setWhere(['name' => $name])
+                ->select('name');
+
+            return $sql->getRows() != 0;
+        } catch (\rex_sql_exception $e) {
+            \rex_logger::logException($e);
+            return false;
+        }
     }
 
     /**


### PR DESCRIPTION
## profileExists kaputt

wenn keine Zeile in der Datenbank existiert hat `getProfile()` durch `sql->getRow()` einen Fehler geworfen und immer true durchgegeben.

## description als String

Description ist in der Datenbank als String abgelegt, keine Ahnung wieso die Funktion da drin war ;) 