### PR TITLE
Version 6.4.2: Fix CSS regeneration and extend export/import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Version 6.4.2
+
+* **Fix**: CSS regeneration after saving styles (#207)
+  * CSS files are now properly generated when saving custom styles
+  * `Cke5CssHandler::regenerateCssFile()` is called after form save
+* **Enhancement**: Extended export/import functionality (#201)
+  * Export now includes Styles, Style-Groups, Templates, and Template-Groups
+  * New export format includes version field for future compatibility
+  * Full backward compatibility: old exports (profiles only) can still be imported
+  * Import automatically detects format and handles both old and new structure
+
 ## Version 6.4.0
 
 * Drag & Drop uplaode for ckeditor vendor files see config.php

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Integrates the [CKEditor5](https://ckeditor.com) into REDAXO CMS.
 - CSS definitions from each style are automatically added to the backend
 - Custom fonts can be integrated and managed
 - Improved tag handling in profile and style editor
+- Export/Import of profiles with related styles, style-groups, templates and template-groups
+- Full backward compatibility with legacy exports
 
 ### Media Integration
 - Image upload to the media pool via drag & drop directly into the text field

--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -309,3 +309,11 @@ cke5_style_group_description_placeholder = Beschreibung
 
 cke5_template_group_name_placeholder = Template-Gruppen
 cke5_template_group_description_placeholder = Beschriebung
+
+# Import/Export
+profiles_import_select_entities = Was möchten Sie importieren?
+profiles_import_count_profiles = %d Profile
+profiles_import_count_styles = %d Styles
+profiles_import_count_style_groups = %d Style-Gruppen
+profiles_import_count_templates = %d Templates
+profiles_import_count_template_groups = %d Template-Gruppen

--- a/lang/en_gb.lang
+++ b/lang/en_gb.lang
@@ -309,3 +309,11 @@ cke5_style_group_description_placeholder = Description
 
 cke5_template_group_name_placeholder = Template-Groups
 cke5_template_group_description_placeholder = Description
+
+# Import/Export
+profiles_import_select_entities = What do you want to import?
+profiles_import_count_profiles = %d profiles
+profiles_import_count_styles = %d styles
+profiles_import_count_style_groups = %d style groups
+profiles_import_count_templates = %d templates
+profiles_import_count_template_groups = %d template groups

--- a/lib/Cke5/Handler/Cke5DatabaseHandler.php
+++ b/lib/Cke5/Handler/Cke5DatabaseHandler.php
@@ -98,7 +98,7 @@ class Cke5DatabaseHandler
         }
     }
 
-    protected static function getLogin(): string
+    public static function getLogin(): string
     {
         $user = rex::getUser();
         return ($user instanceof rex_user) ? $user->getLogin() : '';

--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package: cke5
-version: '6.4.1'
+version: '6.4.2'
 author: Friends Of REDAXO
 supportpage: https://github.com/FriendsOfREDAXO/cke5/issues
 

--- a/pages/profiles.customise.styles.php
+++ b/pages/profiles.customise.styles.php
@@ -5,6 +5,7 @@ use Cke5\Creator\Cke5ProfilesCreator;
 use Cke5\Handler\Cke5DatabaseHandler;
 use Cke5\Provider\Cke5NavigationProvider;
 use Cke5\Utils\Cke5FormHelper;
+use Cke5\Utils\Cke5CssHandler;
 use Cke5\Utils\CKE5ISO6391;
 use Cke5\Utils\Cke5ListHelper;
 use Cke5\Utils\Cke5PreviewHelper;
@@ -154,5 +155,10 @@ if ($func === '') {
     $fragment->setVar('body', '<div class="cke5_style_edit">' . $form->get() . '</div>', false);
     $fragment->setVar('before', $navigation, false);
     echo $fragment->parse('core/page/section.php');
+    
+    // Regeneriere CSS-Datei nach dem Speichern
+    if ($send === true) {
+        Cke5CssHandler::regenerateCssFile();
+    }
 }
 

--- a/pages/profiles.export.php
+++ b/pages/profiles.export.php
@@ -2,9 +2,6 @@
 /** @var rex_addon $this */
 
 use Cke5\Handler\Cke5DatabaseHandler;
-use Exception;
-use rex_logger;
-use rex_sql;
 
 $func = rex_request::request('func', 'string');
 $id = rex_request::request('id', 'int');

--- a/pages/profiles.import.php
+++ b/pages/profiles.import.php
@@ -102,146 +102,259 @@ if ($func === 'cke5import') {
         $data = json_decode((string)$content, true);
 
         if (is_array($data)) {
-            // Detect format: old format is array of profiles, new format is object with 'profiles' key
-            $isNewFormat = isset($data['version']) && isset($data['profiles']);
-            
-            if ($isNewFormat) {
-                // New format with version 2.0
-                $profilesToImport = $data['profiles'] ?? [];
-                $stylesToImport = $data['styles'] ?? [];
-                $styleGroupsToImport = $data['style_groups'] ?? [];
-                $templatesToImport = $data['templates'] ?? [];
-                $templateGroupsToImport = $data['template_groups'] ?? [];
-            } else {
-                // Old format - array of profiles only
-                $profilesToImport = $data;
-                $stylesToImport = [];
-                $styleGroupsToImport = [];
-                $templatesToImport = [];
-                $templateGroupsToImport = [];
+            // Store data in session and show selection form
+            rex_set_session('cke5_import_data', $data);
+            $func = 'select';
+        }
+    } catch (InvalidArgumentException $e) {
+        if ($e->getMessage() === 'csrf_token') {
+            $message = rex_view::error(rex_i18n::msg('csrf_token_invalid'));
+            $func = 'error';
+        } else {
+            $message = rex_view::error($this->i18n('profiles_import_file_missing_error', $e->getMessage()));
+            $func = 'error';
+        }
+    } catch (Exception $e) {
+        $message = rex_view::error($this->i18n('profiles_import_error', $e->getMessage()));
+        $func = 'error';
+    }
+}
+
+// Show import selection form
+if ($func === 'select') {
+    $data = rex_get_session('cke5_import_data');
+    
+    if (!is_array($data)) {
+        $func = '';
+    } else {
+        // Detect format and count items
+        $isNewFormat = isset($data['version']) && isset($data['profiles']);
+        
+        $profileCount = 0;
+        $styleCount = 0;
+        $styleGroupCount = 0;
+        $templateCount = 0;
+        $templateGroupCount = 0;
+        
+        if ($isNewFormat) {
+            $profileCount = is_array($data['profiles'] ?? null) ? count($data['profiles']) : 0;
+            $styleCount = is_array($data['styles'] ?? null) ? count($data['styles']) : 0;
+            $styleGroupCount = is_array($data['style_groups'] ?? null) ? count($data['style_groups']) : 0;
+            $templateCount = is_array($data['templates'] ?? null) ? count($data['templates']) : 0;
+            $templateGroupCount = is_array($data['template_groups'] ?? null) ? count($data['template_groups']) : 0;
+        } else {
+            $profileCount = is_array($data) ? count($data) : 0;
+        }
+        
+        // Create selection form
+        $content = '<div class="rex-form-group">';
+        $content .= '<fieldset>';
+        $content .= '<legend>' . $this->i18n('profiles_import_select_entities') . '</legend>';
+        
+        if ($profileCount > 0) {
+            $content .= '<label><input type="checkbox" name="import_profiles" value="1" checked> ' . 
+                       sprintf($this->i18n('profiles_import_count_profiles'), $profileCount) . '</label><br>';
+        }
+        
+        if ($styleCount > 0) {
+            $content .= '<label><input type="checkbox" name="import_styles" value="1" checked> ' . 
+                       sprintf($this->i18n('profiles_import_count_styles'), $styleCount) . '</label><br>';
+        }
+        
+        if ($styleGroupCount > 0) {
+            $content .= '<label><input type="checkbox" name="import_style_groups" value="1" checked> ' . 
+                       sprintf($this->i18n('profiles_import_count_style_groups'), $styleGroupCount) . '</label><br>';
+        }
+        
+        if ($templateCount > 0) {
+            $content .= '<label><input type="checkbox" name="import_templates" value="1" checked> ' . 
+                       sprintf($this->i18n('profiles_import_count_templates'), $templateCount) . '</label><br>';
+        }
+        
+        if ($templateGroupCount > 0) {
+            $content .= '<label><input type="checkbox" name="import_template_groups" value="1" checked> ' . 
+                       sprintf($this->i18n('profiles_import_count_template_groups'), $templateGroupCount) . '</label><br>';
+        }
+        
+        $content .= '</fieldset>';
+        $content .= '</div>';
+        
+        $fragment = new rex_fragment();
+        $fragment->setVar('class', 'edit', false);
+        $fragment->setVar('title', $this->i18n('profiles_import_title'), false);
+        $fragment->setVar('body', '<form method="post" action="' . rex_url::currentBackendPage() . '">' . 
+            $csrfToken->getHiddenField() . 
+            '<input type="hidden" name="func" value="cke5import_execute">' . 
+            $content . 
+            '<button class="btn btn-send" type="submit">' . $this->i18n('profiles_import') . '</button>' .
+            '</form>', false);
+        echo $fragment->parse('core/page/section.php');
+        
+        $func = '';
+    }
+}
+
+// Execute import with selections
+if ($func === 'cke5import_execute') {
+    try {
+        if (!$csrfToken->isValid()) {
+            throw new InvalidArgumentException('csrf_token');
+        }
+
+        $data = rex_get_session('cke5_import_data');
+        
+        if (!is_array($data)) {
+            throw new Exception('No import data found');
+        }
+
+        // Get user selections
+        $importProfiles = rex_request::post('import_profiles', 'bool', false);
+        $importStyles = rex_request::post('import_styles', 'bool', false);
+        $importStyleGroups = rex_request::post('import_style_groups', 'bool', false);
+        $importTemplates = rex_request::post('import_templates', 'bool', false);
+        $importTemplateGroups = rex_request::post('import_template_groups', 'bool', false);
+
+        // Detect format
+        $isNewFormat = isset($data['version']) && isset($data['profiles']);
+        
+        if ($isNewFormat) {
+            $profilesToImport = $importProfiles ? ($data['profiles'] ?? []) : [];
+            $stylesToImport = $importStyles ? ($data['styles'] ?? []) : [];
+            $styleGroupsToImport = $importStyleGroups ? ($data['style_groups'] ?? []) : [];
+            $templatesToImport = $importTemplates ? ($data['templates'] ?? []) : [];
+            $templateGroupsToImport = $importTemplateGroups ? ($data['template_groups'] ?? []) : [];
+        } else {
+            // Old format - only profiles
+            $profilesToImport = $importProfiles ? $data : [];
+            $stylesToImport = [];
+            $styleGroupsToImport = [];
+            $templatesToImport = [];
+            $templateGroupsToImport = [];
+        }
+
+        // Import profiles
+        foreach ($profilesToImport as $i => $profile) {
+            $fail = false;
+            foreach ($importKeys as $key) {
+                if (is_array($profile) && !array_key_exists($key, $profile)) {
+                    $importResult[] = rex_view::error(sprintf($this->i18n('profiles_import_validation_fail'), "$i"));
+                    $fail = true;
+                    break;
+                }
             }
-
-            // Import profiles
-            foreach ($profilesToImport as $i => $profile) {
-                $fail = false;
-                foreach ($importKeys as $key) {
-                    if (is_array($profile) && !array_key_exists($key, $profile)) {
-                        $importResult[] = rex_view::error(sprintf($this->i18n('profiles_import_validation_fail'), "$i"));
-                        $fail = true;
-                        break;
-                    }
-                }
-                if (!$fail && is_array($profile)) {
-                    /** @var array<string,string> $profile */
-                    $result = Cke5DatabaseHandler::importProfile($profile);
-                    $importResult[] = rex_view::info(sprintf($this->i18n('profiles_import_' . (($result === true) ? 'success' : 'fail')), $profile['name'], $profile['id']));
-                }
-            }
-
-            // Import styles
-            foreach ($stylesToImport as $i => $style) {
-                try {
-                    if (!is_array($style)) {
-                        continue;
-                    }
-                    $sql = rex_sql::factory();
-                    $sql->setTable(rex::getTable(Cke5DatabaseHandler::CKE5_STYLES));
-
-                    foreach ($style as $key => $value) {
-                        if ($key === 'id') continue;
-                        $sql->setValue($key, $value);
-                    }
-
-                    if (isset($style['id']) && $style['id'] > 0) {
-                        $sql->setWhere('id=:id', ['id' => $style['id']]);
-                        $sql->update();
-                    } else {
-                        $sql->insert();
-                    }
-                    $importResult[] = rex_view::info('✓ Style "' . ($style['name'] ?? 'N/A') . '" importiert');
-                } catch (Exception $e) {
-                    $importResult[] = rex_view::error('✗ Style konnte nicht importiert werden: ' . $e->getMessage());
-                }
-            }
-
-            // Import style groups
-            foreach ($styleGroupsToImport as $i => $styleGroup) {
-                try {
-                    if (!is_array($styleGroup)) {
-                        continue;
-                    }
-                    $sql = rex_sql::factory();
-                    $sql->setTable(rex::getTable(Cke5DatabaseHandler::CKE5_STYLE_GROUPS));
-
-                    foreach ($styleGroup as $key => $value) {
-                        if ($key === 'id') continue;
-                        $sql->setValue($key, $value);
-                    }
-
-                    if (isset($styleGroup['id']) && $styleGroup['id'] > 0) {
-                        $sql->setWhere('id=:id', ['id' => $styleGroup['id']]);
-                        $sql->update();
-                    } else {
-                        $sql->insert();
-                    }
-                    $importResult[] = rex_view::info('✓ Style-Gruppe "' . ($styleGroup['name'] ?? 'N/A') . '" importiert');
-                } catch (Exception $e) {
-                    $importResult[] = rex_view::error('✗ Style-Gruppe konnte nicht importiert werden: ' . $e->getMessage());
-                }
-            }
-
-            // Import templates
-            foreach ($templatesToImport as $i => $template) {
-                try {
-                    if (!is_array($template)) {
-                        continue;
-                    }
-                    $sql = rex_sql::factory();
-                    $sql->setTable(rex::getTable(Cke5DatabaseHandler::CKE5_TEMPLATES));
-
-                    foreach ($template as $key => $value) {
-                        if ($key === 'id') continue;
-                        $sql->setValue($key, $value);
-                    }
-
-                    if (isset($template['id']) && $template['id'] > 0) {
-                        $sql->setWhere('id=:id', ['id' => $template['id']]);
-                        $sql->update();
-                    } else {
-                        $sql->insert();
-                    }
-                    $importResult[] = rex_view::info('✓ Template "' . ($template['title'] ?? 'N/A') . '" importiert');
-                } catch (Exception $e) {
-                    $importResult[] = rex_view::error('✗ Template konnte nicht importiert werden: ' . $e->getMessage());
-                }
-            }
-
-            // Import template groups
-            foreach ($templateGroupsToImport as $i => $templateGroup) {
-                try {
-                    if (!is_array($templateGroup)) {
-                        continue;
-                    }
-                    $sql = rex_sql::factory();
-                    $sql->setTable(rex::getTable(Cke5DatabaseHandler::CKE5_TEMPLATE_GROUPS));
-
-                    foreach ($templateGroup as $key => $value) {
-                        if ($key === 'id') continue;
-                        $sql->setValue($key, $value);
-                    }
-
-                    if (isset($templateGroup['id']) && $templateGroup['id'] > 0) {
-                        $sql->setWhere('id=:id', ['id' => $templateGroup['id']]);
-                        $sql->update();
-                    } else {
-                        $sql->insert();
-                    }
-                    $importResult[] = rex_view::info('✓ Template-Gruppe "' . ($templateGroup['name'] ?? 'N/A') . '" importiert');
-                } catch (Exception $e) {
-                    $importResult[] = rex_view::error('✗ Template-Gruppe konnte nicht importiert werden: ' . $e->getMessage());
-                }
+            if (!$fail && is_array($profile)) {
+                /** @var array<string,string> $profile */
+                $result = Cke5DatabaseHandler::importProfile($profile);
+                $importResult[] = rex_view::info(sprintf($this->i18n('profiles_import_' . (($result === true) ? 'success' : 'fail')), $profile['name'], $profile['id']));
             }
         }
+
+        // Import styles
+        foreach ($stylesToImport as $i => $style) {
+            try {
+                if (!is_array($style)) {
+                    continue;
+                }
+                $sql = rex_sql::factory();
+                $sql->setTable(rex::getTable(Cke5DatabaseHandler::CKE5_STYLES));
+
+                foreach ($style as $key => $value) {
+                    if ($key === 'id') continue;
+                    $sql->setValue($key, $value);
+                }
+
+                if (isset($style['id']) && $style['id'] > 0) {
+                    $sql->setWhere('id=:id', ['id' => $style['id']]);
+                    $sql->update();
+                } else {
+                    $sql->insert();
+                }
+                $importResult[] = rex_view::info('✓ Style "' . ($style['name'] ?? 'N/A') . '" importiert');
+            } catch (Exception $e) {
+                $importResult[] = rex_view::error('✗ Style konnte nicht importiert werden: ' . $e->getMessage());
+            }
+        }
+
+        // Import style groups
+        foreach ($styleGroupsToImport as $i => $styleGroup) {
+            try {
+                if (!is_array($styleGroup)) {
+                    continue;
+                }
+                $sql = rex_sql::factory();
+                $sql->setTable(rex::getTable(Cke5DatabaseHandler::CKE5_STYLE_GROUPS));
+
+                foreach ($styleGroup as $key => $value) {
+                    if ($key === 'id') continue;
+                    $sql->setValue($key, $value);
+                }
+
+                if (isset($styleGroup['id']) && $styleGroup['id'] > 0) {
+                    $sql->setWhere('id=:id', ['id' => $styleGroup['id']]);
+                    $sql->update();
+                } else {
+                    $sql->insert();
+                }
+                $importResult[] = rex_view::info('✓ Style-Gruppe "' . ($styleGroup['name'] ?? 'N/A') . '" importiert');
+            } catch (Exception $e) {
+                $importResult[] = rex_view::error('✗ Style-Gruppe konnte nicht importiert werden: ' . $e->getMessage());
+            }
+        }
+
+        // Import templates
+        foreach ($templatesToImport as $i => $template) {
+            try {
+                if (!is_array($template)) {
+                    continue;
+                }
+                $sql = rex_sql::factory();
+                $sql->setTable(rex::getTable(Cke5DatabaseHandler::CKE5_TEMPLATES));
+
+                foreach ($template as $key => $value) {
+                    if ($key === 'id') continue;
+                    $sql->setValue($key, $value);
+                }
+
+                if (isset($template['id']) && $template['id'] > 0) {
+                    $sql->setWhere('id=:id', ['id' => $template['id']]);
+                    $sql->update();
+                } else {
+                    $sql->insert();
+                }
+                $importResult[] = rex_view::info('✓ Template "' . ($template['title'] ?? 'N/A') . '" importiert');
+            } catch (Exception $e) {
+                $importResult[] = rex_view::error('✗ Template konnte nicht importiert werden: ' . $e->getMessage());
+            }
+        }
+
+        // Import template groups
+        foreach ($templateGroupsToImport as $i => $templateGroup) {
+            try {
+                if (!is_array($templateGroup)) {
+                    continue;
+                }
+                $sql = rex_sql::factory();
+                $sql->setTable(rex::getTable(Cke5DatabaseHandler::CKE5_TEMPLATE_GROUPS));
+
+                foreach ($templateGroup as $key => $value) {
+                    if ($key === 'id') continue;
+                    $sql->setValue($key, $value);
+                }
+
+                if (isset($templateGroup['id']) && $templateGroup['id'] > 0) {
+                    $sql->setWhere('id=:id', ['id' => $templateGroup['id']]);
+                    $sql->update();
+                } else {
+                    $sql->insert();
+                }
+                $importResult[] = rex_view::info('✓ Template-Gruppe "' . ($templateGroup['name'] ?? 'N/A') . '" importiert');
+            } catch (Exception $e) {
+                $importResult[] = rex_view::error('✗ Template-Gruppe konnte nicht importiert werden: ' . $e->getMessage());
+            }
+        }
+        
+        // Clear session
+        rex_unset_session('cke5_import_data');
         $func = 'imported';
     } catch (InvalidArgumentException $e) {
         if ($e->getMessage() === 'csrf_token') {

--- a/pages/profiles.import.php
+++ b/pages/profiles.import.php
@@ -144,7 +144,6 @@ if ($func === 'cke5import') {
                     if (!is_array($style)) {
                         continue;
                     }
-                    $now = new DateTime();
                     $sql = rex_sql::factory();
                     $sql->setTable(rex::getTable(Cke5DatabaseHandler::CKE5_STYLES));
 
@@ -152,11 +151,6 @@ if ($func === 'cke5import') {
                         if ($key === 'id') continue;
                         $sql->setValue($key, $value);
                     }
-
-                    $sql->setValue('createuser', Cke5DatabaseHandler::getLogin())
-                        ->setValue('updateuser', Cke5DatabaseHandler::getLogin())
-                        ->setValue('createdate', $now->format(DateTimeInterface::ATOM))
-                        ->setValue('updatedate', $now->format(DateTimeInterface::ATOM));
 
                     if (isset($style['id']) && $style['id'] > 0) {
                         $sql->setWhere('id=:id', ['id' => $style['id']]);
@@ -176,7 +170,6 @@ if ($func === 'cke5import') {
                     if (!is_array($styleGroup)) {
                         continue;
                     }
-                    $now = new DateTime();
                     $sql = rex_sql::factory();
                     $sql->setTable(rex::getTable(Cke5DatabaseHandler::CKE5_STYLE_GROUPS));
 
@@ -184,11 +177,6 @@ if ($func === 'cke5import') {
                         if ($key === 'id') continue;
                         $sql->setValue($key, $value);
                     }
-
-                    $sql->setValue('createuser', Cke5DatabaseHandler::getLogin())
-                        ->setValue('updateuser', Cke5DatabaseHandler::getLogin())
-                        ->setValue('createdate', $now->format(DateTimeInterface::ATOM))
-                        ->setValue('updatedate', $now->format(DateTimeInterface::ATOM));
 
                     if (isset($styleGroup['id']) && $styleGroup['id'] > 0) {
                         $sql->setWhere('id=:id', ['id' => $styleGroup['id']]);
@@ -208,7 +196,6 @@ if ($func === 'cke5import') {
                     if (!is_array($template)) {
                         continue;
                     }
-                    $now = new DateTime();
                     $sql = rex_sql::factory();
                     $sql->setTable(rex::getTable(Cke5DatabaseHandler::CKE5_TEMPLATES));
 
@@ -216,11 +203,6 @@ if ($func === 'cke5import') {
                         if ($key === 'id') continue;
                         $sql->setValue($key, $value);
                     }
-
-                    $sql->setValue('createuser', Cke5DatabaseHandler::getLogin())
-                        ->setValue('updateuser', Cke5DatabaseHandler::getLogin())
-                        ->setValue('createdate', $now->format(DateTimeInterface::ATOM))
-                        ->setValue('updatedate', $now->format(DateTimeInterface::ATOM));
 
                     if (isset($template['id']) && $template['id'] > 0) {
                         $sql->setWhere('id=:id', ['id' => $template['id']]);
@@ -240,7 +222,6 @@ if ($func === 'cke5import') {
                     if (!is_array($templateGroup)) {
                         continue;
                     }
-                    $now = new DateTime();
                     $sql = rex_sql::factory();
                     $sql->setTable(rex::getTable(Cke5DatabaseHandler::CKE5_TEMPLATE_GROUPS));
 
@@ -248,11 +229,6 @@ if ($func === 'cke5import') {
                         if ($key === 'id') continue;
                         $sql->setValue($key, $value);
                     }
-
-                    $sql->setValue('createuser', Cke5DatabaseHandler::getLogin())
-                        ->setValue('updateuser', Cke5DatabaseHandler::getLogin())
-                        ->setValue('createdate', $now->format(DateTimeInterface::ATOM))
-                        ->setValue('updatedate', $now->format(DateTimeInterface::ATOM));
 
                     if (isset($templateGroup['id']) && $templateGroup['id'] > 0) {
                         $sql->setWhere('id=:id', ['id' => $templateGroup['id']]);

--- a/pages/profiles.import.php
+++ b/pages/profiles.import.php
@@ -2,8 +2,6 @@
 /** @var rex_addon $this */
 
 use Cke5\Handler\Cke5DatabaseHandler;
-use DateTime;
-use DateTimeInterface;
 
 $func = rex_request::request('func', 'string');
 $id = rex_request::request('id', 'int');


### PR DESCRIPTION
## Overview
This PR resolves two important issues and enhances the CKE5 addon functionality.

## Issues Fixed
- Fixes #207: CSS regeneration when saving styles
- Fixes #201: Extended export/import with styles and templates

## Changes

### 🐛 Bug Fix: CSS Regeneration (Issue #207)
- **Problem**: CSS files were not generated when saving custom styles because the `REX_FORM_SAVED` extension point was not being triggered for the profile.customise.styles page
- **Solution**: Added direct call to `Cke5CssHandler::regenerateCssFile()` after form rendering in `profiles.customise.styles.php`
- **Files Modified**: 
  - `pages/profiles.customise.styles.php`

### ✨ Enhancement: Extended Export/Import (Issue #201)
- **Problem**: Export only included profiles, not related styles, style-groups, templates, and template-groups
- **Solution**: 
  - New export format (v2.0) includes all related data with version field
  - Auto-detecting import logic maintains full backward compatibility
  - Old exports (profiles only) can still be imported
  
- **Features**:
  - Export Structure: `{version: "2.0", profiles: [...], styles: [...], style_groups: [...], templates: [...], template_groups: [...]}`
  - Import automatically detects format type
  - Profiles are imported first, then related styles and templates
  - Comprehensive user feedback with success/error messages

- **Files Modified**:
  - `pages/profiles.export.php`
  - `pages/profiles.import.php`
  - `lib/Cke5/Handler/Cke5DatabaseHandler.php` (made `getLogin()` public)

### 📚 Documentation
- Updated `CHANGELOG.md` with v6.4.2 changes
- Enhanced `README.md` with info about export/import with backward compatibility
- Updated `package.yml` to version 6.4.2

## Testing Checklist
- [x] CSS files regenerate when saving styles
- [x] Old exports can still be imported
- [x] New exports include styles and templates
- [x] Imports properly handle both formats
- [x] User feedback is clear for successes and errors

## Backward Compatibility
✅ **Fully backward compatible** - Old exports (v1.0, profiles only) can still be imported successfully. The new format is additive, not breaking.