### PR TITLE
Add 'form-control' class to text area fields

### DIFF
--- a/pages/profiles.profiles.php
+++ b/pages/profiles.profiles.php
@@ -398,13 +398,13 @@ if ($func === '') {
             // text area
             $field = $form->addTextAreaField('expert_definition');
             $field->setAttribute('id', 'cke5-expert-definition-area');
-            $field->setAttribute('class', 'rex-code');
+            $field->setAttribute('class', 'rex-code form-control');
             $field->setAttribute('rows', '5');
             $field->setLabel(rex_i18n::msg('cke5_expert_definition_area'));
             // text area
             $field = $form->addTextAreaField('expert_suboption');
             $field->setAttribute('id', 'cke5-expert-suboption-area');
-            $field->setAttribute('class', 'rex-code');
+            $field->setAttribute('class', 'rex-code form-control');
             $field->setAttribute('rows', '5');
             $field->setLabel(rex_i18n::msg('cke5_expert_suboption_area'));
         // end collapse


### PR DESCRIPTION
In add-on version 6.X the expert definition and expert suboption fields used to be full width and styled as "form-control". This fix restored the proper styling.